### PR TITLE
Adds container editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 node_modules
+# Ignored since it's copied from the compiled typescript. See package.json build
+public/js
 

--- a/models/containers.ts
+++ b/models/containers.ts
@@ -1,14 +1,14 @@
 // Represents the type of container an item might be in
 export class ItemContainer {
-    id: number;
+    id: number | null;
     // Represents the type of container, e.g., "Craftmaster" or "Crowler"
-    containerName: string;
+    containerName: string | null;
     // How we would like the container to show up in the system, e.g., "Full Pour" or "Taster"
-    displayName: string;
+    displayName: string | null;
     // The order we'd like this to show up in columns on a menu, ascending
-    order: number;
+    order: number | null;
 
-    constructor(id: number, containerName: string, displayName: string, order: number){
+    constructor(id: number | null, containerName: string | null, displayName: string | null, order: number | null){
         this.id = id;
         this.containerName = containerName;
         this.displayName = displayName;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "prettier": "^3.5.3",
         "sharp": "^0.34.5",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "uuid": "^13.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -3314,6 +3315,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "tsc && yarn copy-files && cp -r dist/routes/viewHelpers/*.js public/js/",
+    "build": "tsc && yarn copy-files && rm -r public/js/* && cp -r dist/routes/viewHelpers/*.js public/js/",
     "start": "node dist/server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "copy-files": "cp -r public dist"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "^3.5.3",
     "sharp": "^0.34.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "uuid": "^13.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "tsc && yarn copy-files",
+    "build": "tsc && yarn copy-files && cp -r dist/routes/viewHelpers/*.js public/js/",
     "start": "node dist/server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "copy-files": "cp -r public dist"

--- a/public/views/breweryList.pug
+++ b/public/views/breweryList.pug
@@ -5,56 +5,9 @@ script.
 script(src="/functions.js")
 
 script.
-  function toggleShowElement(divId) {
-    var element = document.querySelector(`#${divId}`);
-    element.style.display = element.style.display === "none" ? "" : "none";
-  }
-
-script.
-  function isFormTextValueValid(form, fieldName) {
-    const value = form[fieldName].value;
-    if (value == "") {
-      alert(`${fieldName} must be filled out`);
-      return false;
-    }
-    return true;
-  }
-
-  function setB64FormFieldFromImage(form) {
-    const logoFileElement = form.newBreweryLogo;
-    const files = logoFileElement.files;
-    if (files && files.length > 0) {
-      // Assume a single file
-      const file = files[0];
-      const reader = new FileReader();
-
-      reader.onload = function (e) {
-        // The result is a Data URL (e.g., "data:image/jpeg;base64,<the stuff we want as b64 data>")
-        const dataURL = e.target.result;
-        const base64String = dataURL.split(',')[1]; 
-
-        const b64FormElement = form.newBreweryLogoB64;
-        b64FormElement.value = base64String;
-      };
-
-      reader.readAsDataURL(file);
-    }
-  }
-
-  function setItemIdFormField(itemId) {
-    const formElement = document.getElementById('newItemIdHidden');
-    formElement.value = itemId;
-  }
-
-  function stringifyForm(form) {
-    const formData = new FormData(form);
-    const formObject = Object.fromEntries(formData.entries());
-    return JSON.stringify(formObject); 
-  }
-
   function submitAddForm(formId) {
     const form = document.getElementById(formId);
-    setB64FormFieldFromImage(form);
+    setB64FormFieldFromImage(form, 'newBreweryLogo', 'newBreweryLogoB64');
     if (!isFormTextValueValid(form, 'newBreweryName')) {
       return;
     }
@@ -83,7 +36,7 @@ script.
 
   function submitEditForm(formId, breweryId) {
     const form = document.getElementById(formId);
-    setB64FormFieldFromImage(form);
+    setB64FormFieldFromImage(form, 'newBreweryLogo', 'newBreweryLogoB64');
 
     const jsonString = stringifyForm(form);
 
@@ -105,14 +58,14 @@ html
   body
     table
       button(onclick="toggleShowElement('createBreweryDiv')") Add New
-      div(style="display: none;", id="createBreweryDiv")
+      div(style="display: none", id="createBreweryDiv")
         form(action="/breweries?callbackUrl=/breweries/manage" method="POST" id="addBreweryForm")
           label(for="newBreweryName") Name:
           input(name="newBreweryName" id="newBreweryName")
           label(for="newBreweryLocation") Location:
           input(name="newBreweryLocation" id="newBreweryLocation")
           label(for="newBreweryLogo") Logo:
-          input(name="newBreweryLogo" id="newBreweryLogo" type="file" accept="image/png, image/jpeg" onchange="setB64FormFieldFromImage(document.getElementById('addBreweryForm'))")
+          input(name="newBreweryLogo" id="newBreweryLogo" type="file" accept="image/png, image/jpeg" onchange="setB64FormFieldFromImage(document.getElementById('addBreweryForm'), 'newBreweryLogo', 'newBreweryLogoB64')")
           input(name="newBreweryLogoB64" id="newBreweryLogoB64" type="hidden")
         button(onclick="submitAddForm('addBreweryForm')" type="button") Create Brewery
       tbody
@@ -132,11 +85,11 @@ html
             td #{location}
             td
               button(onclick=`toggleShowElement('editBreweryElement${breweryId}')`) Edit
-          tr(style="display: none;", id=`editBreweryElement${breweryId}`)
+          tr(style="display: none", id=`editBreweryElement${breweryId}`)
             form(action=`/breweries/${breweryId}?callbackUrl=/breweries/manage` id=`updateBreweryForm${breweryId}`)
               td
                 label(for="newBreweryLogo") Logo:
-                input(name="newBreweryLogo" id="newBreweryLogo" type="file" accept="image/png, image/jpeg" onchange=`setB64FormFieldFromImage(document.getElementById('updateBreweryForm${breweryId}'))`)
+                input(name="newBreweryLogo" id="newBreweryLogo" type="file" accept="image/png, image/jpeg" onchange=`setB64FormFieldFromImage(document.getElementById('updateBreweryForm${breweryId}'), 'newBreweryLogo', 'newBreweryLogoB64')`)
               td
                 label(for="newBreweryName") Name:
                 input(name="newBreweryName" id="newBreweryName")

--- a/public/views/breweryList.pug
+++ b/public/views/breweryList.pug
@@ -1,4 +1,8 @@
 <link rel="stylesheet" type="text/css" href="/editor.css" />
+script.
+  var exports = {};
+
+script(src="/functions.js")
 
 script.
   function toggleShowElement(divId) {

--- a/public/views/containerList.pug
+++ b/public/views/containerList.pug
@@ -1,0 +1,94 @@
+<link rel="stylesheet" type="text/css" href="/editor.css" />
+script.
+  var exports = {};
+
+script(src="/functions.js")
+
+script.
+  function submitAddForm(formId) {
+    const form = document.getElementById(formId);
+    if (!isFormTextValueValid(form, 'containerName')) {
+      return;
+    }
+    if (!isFormTextValueValid(form, 'displayName')) {
+      return;
+    }
+
+    const jsonString = stringifyForm(form);
+
+    fetch(`/containers`, {
+      method:'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: jsonString
+    }).then(data => {
+      window.location.reload();
+    })
+    .catch(error => {
+      alert(`Problem making request: ${error}`);
+    });
+  }
+
+  function submitEditForm(formId, itemId) {
+    const form = document.getElementById(formId);
+
+    const jsonString = stringifyForm(form);
+
+    fetch(`/containers/${itemId}`, {
+      method:'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: jsonString
+    }).then(data => {
+      window.location.reload();
+    })
+    .catch(error => {
+      alert(`Problem making request: ${error}`);
+    });
+  }
+
+html
+  body
+    table
+      button(onclick="toggleShowElement('createItemNewDiv')") Add New
+      div(style="display: none", id="createItemNewDiv")
+        form(id="addItemForm")
+          label(for="containerName") Internal Name:
+          input(name="containerName" id="containerName")
+          label(for="displayName") Display Name:
+          input(name="displayName" id="displayName")
+          label(for="order") Display Order:
+          input(name="order" id="order")
+        button(onclick="submitAddForm('addItemForm')" type="button") Create Container
+      tbody
+        tr
+          th Internal Name
+          th Display Name
+          th Display Order
+          th 
+        each item in displayList
+          - var name = item.containerName
+          - var location = item.displayName
+          - var order = item.order
+          - var itemId = item.id
+          tr 
+            td #{name}
+            td #{location}
+            td #{order}
+            td
+              button(onclick=`toggleShowElement('editElement${itemId}')`) Edit
+          tr(style="display: none", id=`editElement${itemId}`)
+            form(id=`updateForm${itemId}`)
+              td
+                label(for="containerName") Internal Name:
+                input(name="containerName" id="containerName")
+              td
+                label(for="displayName") Display Name:
+                input(name="displayName" id="displayName")
+              td
+                label(for="order") Display Order:
+                input(name="order" id="order")
+              td
+                button(onclick=`submitEditForm('updateForm${itemId}', '${itemId}')` type="button") Update Container

--- a/routes/breweries.ts
+++ b/routes/breweries.ts
@@ -1,8 +1,7 @@
 import { Request, Response } from 'express';
 import Routes from './common';
 import { Brewery } from '../models/breweries';
-
-const sharp = require('sharp');
+import { toggleShowElement } from './viewHelpers/functions';
 
 export class BreweriesRoutes extends Routes {
   // Order matters here. If we don't specify non-IDs first, they get interpreted as IDs

--- a/routes/containers.ts
+++ b/routes/containers.ts
@@ -6,10 +6,10 @@ export class ContainersRoutes extends Routes {
   requiredFieldsAndTypes: Record<string, string> = {"containerName": "string", "displayName": "string"};
 
   registerRoutes(): void {
-    // Default get
-    // TODO: Should probably list all IDs or something eventually
-    this.router.get("/", (_req: Request, res: Response) => {
-      res.send("Look at all the glasses!");
+    this.router.get("/manage", (_req: Request, res: Response) => {
+      const containerList = this.dataProvider.getContainers();
+      res.render("containerList", {displayList: containerList})
+      return;
     });
 
     // Gets a specific container by ID
@@ -33,6 +33,31 @@ export class ContainersRoutes extends Routes {
       container = this.dataProvider.addContainer(container);
 
       res.send(container);
+    });
+
+    // Update an existing container
+    this.router.patch("/:containerId", (req: Request, res: Response) => {
+      try{
+        if (!req.body) {
+          res.status(400).send("Request body expected");
+          return;
+        }
+        const result = this.dataProvider.updateContainer(parseInt(req.params.containerId), new ItemContainer(null, req.body.containerName, req.body.displayName, req.body.order));
+        if (result !== null) {
+          res.send(result);
+          return;
+        }
+        res.status(400);
+        res.send("Invalid Argument");
+        return
+      } catch(e: any) {
+        const statusCode = "statusCode" in e ? e["statusCode"] : 500;
+        const message = "message" in e ? e["message"] : "Unexpected error occurred";
+        res.status(statusCode);
+        res.send(message);
+      }
+      
+      return
     });
   }
 }

--- a/routes/menus.ts
+++ b/routes/menus.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import Routes from './common';
+import {v4 as uuidv4} from 'uuid';
 import { Item } from '../models/items';
 import { DisplayItem, DisplaySubMenu, MenuItem, SubMenu } from '../models/menus';
 import { Brewery } from '../models/breweries';
@@ -53,7 +54,8 @@ export class MenusRoutes extends Routes {
           const containerDisplayNameToPrice: Map<string, string> = new Map();
           allSaleContainersForItem.forEach(saleContainer => {
             const containerInfo = this.dataProvider.getContainer(saleContainer.containerId)!;
-            containerDisplayNameToPrice.set(containerInfo.displayName, saleContainer.price.toLocaleString('en-US', { minimumFractionDigits: 2}));
+            const workingDisplayName = containerInfo.displayName ? containerInfo.displayName : uuidv4();
+            containerDisplayNameToPrice.set(workingDisplayName, saleContainer.price.toLocaleString('en-US', { minimumFractionDigits: 2}));
 
             // Get the top level display names and orders for the sub menu we're on
             let displayNameToOrder;
@@ -63,9 +65,10 @@ export class MenusRoutes extends Routes {
               displayNameToOrder = subMenuToContainerDisplayNameToOrder.get(-1)!;
             }
 
-            const existingOrderForDisplayName = displayNameToOrder.get(containerInfo.displayName);
-            if (!existingOrderForDisplayName || existingOrderForDisplayName > containerInfo.order) {
-              displayNameToOrder.set(containerInfo.displayName, containerInfo.order);
+            const workingOrder = containerInfo.order ? containerInfo.order : 999;
+            const existingOrderForDisplayName = displayNameToOrder.get(workingDisplayName);
+            if (!existingOrderForDisplayName || existingOrderForDisplayName > workingOrder) {
+              displayNameToOrder.set(workingDisplayName, workingOrder);
             }
           });
 

--- a/routes/viewHelpers/functions.ts
+++ b/routes/viewHelpers/functions.ts
@@ -1,0 +1,6 @@
+// Collection of functions to pass to pug templates for rendering
+
+export function toggleShowElement(divId: string) {
+    const element = document.querySelector(`#${divId}`)!;
+    element.setAttribute("style", element.getAttribute("style") === "display: none" ? "display:" : "display: none");
+}

--- a/routes/viewHelpers/functions.ts
+++ b/routes/viewHelpers/functions.ts
@@ -2,5 +2,42 @@
 
 export function toggleShowElement(divId: string) {
     const element = document.querySelector(`#${divId}`)!;
-    element.setAttribute("style", element.getAttribute("style") === "display: none" ? "display:" : "display: none");
+    const style = element.getAttribute("style");
+    element.setAttribute("style", style === "display: none" || style === undefined ? "display:" : "display: none");
+}
+
+export function isFormTextValueValid(form: any, fieldName: string) {
+    const value = form[fieldName].value;
+    if (value == "") {
+        alert(`${fieldName} must be filled out`);
+        return false;
+    }
+    return true;
+}
+
+export function stringifyForm(form: any) {
+    const formData = new FormData(form);
+    const formObject = Object.fromEntries(formData.entries());
+    return JSON.stringify(formObject); 
+}
+
+export function setB64FormFieldFromImage(form: any, fileInputFieldName: string, b64FieldName: string) {
+    const logoFileElement = form[fileInputFieldName];
+    const files = logoFileElement.files;
+    if (files && files.length > 0) {
+        // Assume a single file
+        const file = files[0];
+        const reader = new FileReader();
+
+        reader.onload = function (e) {
+            // The result is a Data URL (e.g., "data:image/jpeg;base64,<the stuff we want as b64 data>")
+            const dataUrl = e.target?.result as string;
+            const base64String = dataUrl ? dataUrl.split(',')[1] : ''; 
+
+            const b64FormElement = form[b64FieldName];
+            b64FormElement.value = base64String;
+        };
+
+        reader.readAsDataURL(file);
+    }
 }

--- a/server.ts
+++ b/server.ts
@@ -24,6 +24,7 @@ app.listen(port, () => {
 app.set('view engine', 'pug');
 app.set('views', './dist/public/views')
 app.use(express.static(path.join(__dirname, 'public', 'css')));
+app.use(express.static(path.join(__dirname, 'public', 'js')));
 
 // Register routers
 const dataProvider = new LocalDataProvider("./data/");

--- a/storage/providers.ts
+++ b/storage/providers.ts
@@ -23,6 +23,8 @@ export abstract class DataProvider {
 
     abstract addContainer(container: ItemContainer): ItemContainer;
     abstract getContainer(id: number): ItemContainer | null;
+    abstract getContainers(): Array<ItemContainer>;
+    abstract updateContainer(containerId: number, container: ItemContainer): ItemContainer;
 
     abstract addSaleContainer(container: SaleContainer): SaleContainer;
     abstract getSaleContainer(id: number): SaleContainer | null;
@@ -210,6 +212,14 @@ export class LocalDataProvider extends DataProvider {
 
     getContainer(id: number): ItemContainer | null {
         return this.getGeneric(id, this.CONTAINERS_KEY);
+    }
+
+    getContainers(): Array<ItemContainer> {
+        return this.getGenericList(this.CONTAINERS_KEY);
+    }
+
+    updateContainer(containerId: number, container: ItemContainer): ItemContainer {
+        return this.updateGeneric(containerId, this.CONTAINERS_KEY, container, ItemContainer, ['id'])
     }
 
     addSaleContainer(container: SaleContainer): SaleContainer {


### PR DESCRIPTION
Adds a new pug template for editing containers. Cleans up/generalizes a lot of the language for better reuse. May want to clean up the submit form calls a bit on a future template addition, but this works great for now.

Also, pulls some common JS out of the pug templates and into a re-usable TS file. The `package.json` build command was updated to clean a public JS folder, then copy the compiled code out of `dist` into that folder. Might want to update README soon.