### PR TITLE
Fixes up prisma related install issues

### DIFF
--- a/build/app/Dockerfile
+++ b/build/app/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /taproom-offering-engine
 # This allows installing dependencies before copying the entire application code
 COPY package*.json ./
 
+# Copy the generated Prisma files
+COPY prisma ./prisma
+
 # Install dependencies
 RUN npm install
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@
 generator client {
   provider = "prisma-client"
   output   = "../generated/prisma"
-  binaryTargets = ["linux-musl-arm64-openssl-3.0.x"]
+  binaryTargets = ["linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
The original prisma files were compiled against the wrong arch for the docker image. Just tried to install on a new system, and found these were (probably) necessary.